### PR TITLE
Pagination

### DIFF
--- a/ForgetItNot/settings.py
+++ b/ForgetItNot/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 import os
 from pathlib import Path
 
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/ForgetItNot/settings.py
+++ b/ForgetItNot/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 import os
 from pathlib import Path
 
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -130,6 +131,8 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',
     ),
+    'DEFAULT_PAGINATION_CLASS': 'flashcards.pagination.PagesCountPagination',
+    'PAGE_SIZE': 5
 }
 
 DJOSER = {
@@ -154,6 +157,3 @@ EMAIL_USE_TLS = True
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
-
-# DATE_FORMAT = 'N j, Y'
-

--- a/flashcards/pagination.py
+++ b/flashcards/pagination.py
@@ -1,0 +1,20 @@
+from rest_framework import pagination
+from rest_framework.response import Response
+
+
+class PagesCountPagination(pagination.PageNumberPagination):
+    def get_paginated_response(self, data):
+        next_page = self.page.next_page_number() if self.page.has_next() else None
+        previous_page = self.page.previous_page_number() if self.page.has_previous() else None
+
+        return Response({
+            'next_link': self.get_next_link(),
+            'previous_link': self.get_previous_link(),
+            'count': self.page.paginator.count,
+            'total_pages': self.page.paginator.num_pages,
+            'current_page': self.page.number,
+            'next_page': next_page,
+            'previous_page': previous_page,
+            'pages': [x+1 for x in range(self.page.paginator.num_pages)],
+            'results': data
+        })

--- a/flashcards/serializers.py
+++ b/flashcards/serializers.py
@@ -4,6 +4,9 @@ from .models import FlashcardSet, Flashcard
 
 
 class FlashcardSerializer(serializers.ModelSerializer):
+    owner = serializers.HiddenField(
+        default=serializers.CurrentUserDefault()
+    )
     owner_name = serializers.CharField(read_only=True)
     set_name = serializers.CharField(read_only=True)
     set_created = serializers.CharField(read_only=True)

--- a/flashcards/views.py
+++ b/flashcards/views.py
@@ -35,6 +35,7 @@ class FlashcardSetViewSet(viewsets.ModelViewSet):
     queryset = FlashcardSet.objects.all()
     serializer_class = FlashcardSetSerializer
     permission_classes = [IsAuthenticated, IsOwner]
+    pagination_class = None
 
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)


### PR DESCRIPTION
Added pagination, but I'm wondering if that nested serializer is needed, maybe if flashcard-list endpoint is used for browsing, searching in the set, filtering, etc, that nested serializer can be deleted and just leave the ids of flashcards in the set?

I added some pagination fields I believe could be useful for the frontend.

P.S This limit of 5 is just for testing purposes, it will be changed later ;)