### PR TITLE
Dev

### DIFF
--- a/ForgetItNot/settings.py
+++ b/ForgetItNot/settings.py
@@ -145,7 +145,9 @@ DJOSER = {
     'USER_CREATE_PASSWORD_RETYPE': True,
     'SET_PASSWORD_RETYPE': True,
     'PASSWORD_RESET_CONFIRM_RETYPE': True,
-    'SERIALIZERS': {},
+    'SERIALIZERS': {
+        'current_user': 'users.serializers.UserSerializer',
+    },
 }
 
 

--- a/ForgetItNot/urls.py
+++ b/ForgetItNot/urls.py
@@ -18,8 +18,8 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', include('flashcards.urls')),
-    path('', include('users.urls')),
-    path('auth/', include('djoser.urls')),
-    path('auth/', include('djoser.urls.authtoken')),
+    path('api/', include('flashcards.urls')),
+    path('api/', include('users.urls')),
+    path('api/auth/', include('djoser.urls')),
+    path('api/auth/', include('djoser.urls.authtoken')),
 ]

--- a/flashcards/models.py
+++ b/flashcards/models.py
@@ -62,7 +62,7 @@ class Flashcard(models.Model):
         returns: a list of ids of all flashcards that are in the same set as the flashcard with the given id.
         """
         flashcards = Flashcard.objects.filter(flashcard_set=self.flashcard_set)
-        return sorted([flashcard.id for flashcard in flashcards])
+        return sorted([flashcard.id for flashcard in flashcards], reverse=True)
 
     @property
     def next_id(self):

--- a/flashcards/models.py
+++ b/flashcards/models.py
@@ -55,5 +55,29 @@ class Flashcard(models.Model):
     def set_created(self):
         return self.flashcard_set.created
 
+    @property
+    def flashcards_ids(self):
+        """
+        Helps in finding next and previous flashcard to let the user easily browse flashcards from their set.
+        returns: a list of ids of all flashcards that are in the same set as the flashcard with the given id.
+        """
+        flashcards = Flashcard.objects.filter(flashcard_set=self.flashcard_set)
+        return sorted([flashcard.id for flashcard in flashcards])
+
+    @property
+    def next_id(self):
+        index = self.flashcards_ids.index(self.pk)
+        try:
+            return self.flashcards_ids[index + 1]
+        except IndexError:
+            return None
+
+    @property
+    def previous_id(self):
+        index = self.flashcards_ids.index(self.pk)
+        if self.flashcards_ids[0] == self.pk:
+            return None
+        return self.flashcards_ids[index - 1]
+
     def __str__(self):
         return f'{self.front} - {self.back}'

--- a/flashcards/pagination.py
+++ b/flashcards/pagination.py
@@ -8,8 +8,10 @@ class PagesCountPagination(pagination.PageNumberPagination):
         previous_page = self.page.previous_page_number() if self.page.has_previous() else None
 
         return Response({
-            'next_link': self.get_next_link(),
-            'previous_link': self.get_previous_link(),
+            'links': {
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link()
+             },
             'count': self.page.paginator.count,
             'total_pages': self.page.paginator.num_pages,
             'current_page': self.page.number,

--- a/flashcards/serializers.py
+++ b/flashcards/serializers.py
@@ -10,11 +10,13 @@ class FlashcardSerializer(serializers.ModelSerializer):
     owner_name = serializers.CharField(read_only=True)
     set_name = serializers.CharField(read_only=True)
     set_created = serializers.CharField(read_only=True)
+    next_id = serializers.IntegerField(read_only=True, allow_null=True)
+    previous_id = serializers.IntegerField(read_only=True, allow_null=True)
 
     class Meta:
         model = Flashcard
         fields = ['id', 'flashcard_set', 'set_name', 'set_created', 'front', 'back', 'owner', 'owner_name', 'added',
-                  'last_modified']
+                  'last_modified', 'next_id', 'previous_id']
 
 
 class FlashcardSetSerializer(serializers.ModelSerializer):

--- a/flashcards/serializers.py
+++ b/flashcards/serializers.py
@@ -18,7 +18,10 @@ class FlashcardSerializer(serializers.ModelSerializer):
 
 
 class FlashcardSetSerializer(serializers.ModelSerializer):
-    flashcards = FlashcardSerializer(many=True)
+    owner = serializers.HiddenField(
+        default=serializers.CurrentUserDefault()
+    )
+    flashcards = FlashcardSerializer(many=True, required=False)
     owner_name = serializers.CharField(read_only=True)
     num_flashcards = serializers.CharField(read_only=True)
 

--- a/users/models.py
+++ b/users/models.py
@@ -3,7 +3,16 @@ from rest_framework.authtoken.models import Token
 
 
 class User(AbstractUser):
-
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         Token.objects.get_or_create(user=self)
+
+    @property
+    def num_sets(self):
+        from flashcards.models import FlashcardSet
+        return FlashcardSet.objects.filter(owner=self).count()
+
+    @property
+    def num_flashcards(self):
+        from flashcards.models import Flashcard
+        return Flashcard.objects.filter(owner=self).count()

--- a/users/models.py
+++ b/users/models.py
@@ -9,10 +9,8 @@ class User(AbstractUser):
 
     @property
     def num_sets(self):
-        from flashcards.models import FlashcardSet
-        return FlashcardSet.objects.filter(owner=self).count()
+        return self.flashcardset_set.count()
 
     @property
     def num_flashcards(self):
-        from flashcards.models import Flashcard
-        return Flashcard.objects.filter(owner=self).count()
+        return self.flashcard_set.count()

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -3,6 +3,9 @@ from .models import User
 
 
 class UserSerializer(serializers.ModelSerializer):
+    num_flashcards = serializers.CharField(read_only=True)
+    num_sets = serializers.CharField(read_only=True)
+
     class Meta:
         model = User
-        fields = ['username', 'email']
+        fields = ['id', 'username', 'email', 'num_sets', 'num_flashcards']


### PR DESCRIPTION
I replaced djoser serializer for users/me endpoint, since I wanted the number of user's flashcards and sets there.

 I added calculating that previous and next ids, the way it was before, basing only on the id, but I do not like the way it works on the frontend. I was wondering if I could transfer that part to the frontend (that entire previous/next logic) - basing it on flashcard-list endpoint and enabling the user to browse filtered and sorted flashcards. I would load not one flashcard at a time but the whole sorted & paginated part, display one flashcard at a time without refreshing and somehow make it smoothly load the next page,
not disturbing the user in browsing flashcards ;) 